### PR TITLE
Correct package.json license type

### DIFF
--- a/dx-mime-decode/package.json
+++ b/dx-mime-decode/package.json
@@ -4,7 +4,7 @@
   "description": "MIME Decode",
   "main": "index.js",
   "author": "Alan Shurack (ashurack@qmulos.com)",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "dependencies": {
     "libmime": "^5.3.7"
   }

--- a/dx-mime-encode/package.json
+++ b/dx-mime-encode/package.json
@@ -4,7 +4,7 @@
   "description": "MIME Encode",
   "main": "index.js",
   "author": "Alan Shurack (ashurack@qmulos.com)",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "dependencies": {
     "libmime": "^5.3.7"
   }


### PR DESCRIPTION
- Updating both `package.json` to use the correct license type of `MIT` instead of `Apache-2.0`